### PR TITLE
Update rust docs

### DIFF
--- a/src/examples/unofficial/rust.md
+++ b/src/examples/unofficial/rust.md
@@ -7,7 +7,7 @@
 
 ```toml
 [dependencies]
-nekosbest = "0.19"
+nekosbest = "0.20"
 ```
 
 ## Example
@@ -112,6 +112,44 @@ GIF:
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let details = nekosbest::st_get::<nekosbest::Pat>().await?.details;
     println!("Anime name: {}", details.anime_name);
+    Ok(())
+}
+```
+
+## Downloading the images.
+
+With the `download` feature, you can download the images directly, like so:
+
+```rust, noplaypen
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let resp = nekosbest::get(nekosbest::Category::Neko).await?;
+    let image = nekosbest::download::download(&resp).await?;
+    
+    // maybe also save, or just use it directly
+    tokio::task::spawn_blocking(move || image.save("neko.png")).await??;
+
+    // or alternatively, if you just want to save it, without
+    // loading the whole image in-memory:
+    nekosbest::download::download_to_file(&resp, "neko.png").await?;
+    Ok(())
+}
+```
+
+Or directly from a given URL:
+
+```rust, noplaypen
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // let resp = nekosbest::get(nekosbest::Category::Neko).await?;
+    // let url: String = resp.url;
+    let url = "https://nekos.best/api/v2/neko/1efcda2d-d0d3-4e96-9b40-86852374b4bc.png".to_owned();
+    let image = nekosbest::download::download_from_url(&url).await?;
+    tokio::task::spawn_blocking(move || image.save("neko.png")).await??;
+
+    // or alternatively, if you just want to save it, without
+    // loading the whole image in-memory:
+    nekosbest::download::download_from_url_to_file(&url, "neko.png").await?;
     Ok(())
 }
 ```


### PR DESCRIPTION
Update rust docs to 0.20.

From the CHANGELOG:

- Made `Category` `#[non_exhaustive]` to allow for new categories to be added
  without breaking the public API.
- `download` feature: allow the downloading of images directly
  through the library.